### PR TITLE
use volume by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,22 @@ Manage a Docker based OpenVPN instance with ease.
 
 # Overview
 
-`easy_docker_vpn` is a script that manages an instance of OpenVPN running inside of a Docker container.  The image that it uses is [kylemanna/openvpn](https://hub.docker.com/r/kylemanna/openvpn/) ([source here](https://github.com/kylemanna/docker-openvpn)).  There are two containers in the system:
+`easy_docker_vpn` is a script that manages an instance of OpenVPN running inside of a Docker container.  The image that it uses is [kylemanna/openvpn](https://hub.docker.com/r/kylemanna/openvpn/) ([source here](https://github.com/kylemanna/docker-openvpn)).  Here is what the VPN uses:
 
-* ovpn-data - a container based on busybox that specifies a volume for /etc/openvpn
-* openvpn - the container that shares the volume from ovpn-data and runs the actual VPN process
+* ovpn-data - a volume for /etc/openvpn
+* openvpn - the container that uses the ovpn-data volume and runs the actual VPN process
+
+## Migration to volume
+
+NOTE: previous versions of this application used an ovpn-data *container* instead of a *volume*.  If a container is detected, it will continue to be used.
+
+To migrate from the old container mode to the new volume mode is as simple as a backup and restore:
+
+```
+$ easy_docker_vpn backup > temp_backup.tgz
+$ easy_docker_vpn destroy
+$ easy_docker_vpn restore temp_backup.tgz
+```
 
 # Getting Started
 

--- a/funcs.sh
+++ b/funcs.sh
@@ -1,23 +1,53 @@
 function _ensure_no_vpn_data() {
-	if docker ps -a | grep -q $OVPN_DATA; then
-		echo "$OVPN_DATA container found, refusing to continue, use 'easy_docker_vpn destroy' to completely remove vpn"
-		exit 1
+	if [[ "$(_volume_mode)" == "container" ]]; then
+		if docker ps -a | grep -q $OVPN_DATA; then
+			echo "$OVPN_DATA container found, refusing to continue, use 'easy_docker_vpn destroy' to completely remove vpn"
+			exit 1
+		fi
+	else
+		if docker volume ls -q | grep -q $OVPN_DATA; then
+			echo "$OVPN_DATA volume found, refusing to continue, use 'easy_docker_vpn destroy' to completely remove vpn"
+			exit 1
+		fi
 	fi
 }
 
 function _ensure_vpn_data() {
-	if ! docker ps -a | grep -q $OVPN_DATA ; then
-		echo "No $OVPN_DATA found, use 'easy_docker_vpn create' to create a vpn"
-		exit 1
+	if [[ "$(_volume_mode)" == "container" ]]; then
+		if ! docker ps -a | grep -q $OVPN_DATA ; then
+			echo "No $OVPN_DATA found, use 'easy_docker_vpn create' to create a vpn"
+			exit 1
+		fi
+	else
+		if ! docker volume ls -q | grep -q $OVPN_DATA ; then
+			echo "No $OVPN_DATA found, use 'easy_docker_vpn create' to create a vpn"
+			exit 1
+		fi
 	fi
 }
 
 function _restart_vpn() {
 	docker stop $OVPN_CONT
 	docker rm $OVPN_CONT
-	docker run --restart=always --volumes-from $OVPN_DATA --name $OVPN_CONT -d -p 1194:1194/udp --cap-add=NET_ADMIN $OVPN_IMAGE
+	docker run --restart=always $(_volume_arg) --name $OVPN_CONT -d -p 1194:1194/udp --cap-add=NET_ADMIN $OVPN_IMAGE
 }
 
 function _start_vpn() {
-	docker run --restart=always --volumes-from $OVPN_DATA --name $OVPN_CONT -d -p 1194:1194/udp --cap-add=NET_ADMIN $OVPN_IMAGE
+	docker run --restart=always $(_volume_arg) --name $OVPN_CONT -d -p 1194:1194/udp --cap-add=NET_ADMIN $OVPN_IMAGE
+}
+
+function _volume_mode() {
+	if [[ "$(docker ps -a --format '{{.Names}}' --filter name=^/${OVPN_DATA}$)" == "${OVPN_DATA}" ]]; then
+		echo "container"
+	else
+		echo "volume"
+	fi
+}
+
+function _volume_arg() {
+	if [[ "$(_volume_mode)" == "container" ]]; then
+		echo " --volumes-from $OVPN_DATA "
+	else
+		echo " --volume $OVPN_DATA:/etc/openvpn "
+	fi
 }

--- a/libexec/easy_docker_vpn-backup
+++ b/libexec/easy_docker_vpn-backup
@@ -22,4 +22,6 @@ if [ -t 1 ] ; then
 	exit 1
 fi
 
-docker run --volumes-from $OVPN_DATA -a stdout --rm $OVPN_IMAGE tar -czf - /etc/openvpn
+VOLUME_ARG=$(_volume_arg)
+
+docker run $VOLUME_ARG -a stdout --rm $OVPN_IMAGE tar -czf - /etc/openvpn

--- a/libexec/easy_docker_vpn-create
+++ b/libexec/easy_docker_vpn-create
@@ -22,8 +22,10 @@ set -e
 
 _ensure_no_vpn_data
 
-docker create --name $OVPN_DATA -v /etc/openvpn busybox
-docker run --volumes-from $OVPN_DATA --rm $OVPN_IMAGE ovpn_genconfig -e "management localhost 7505" "$@"
-docker run --volumes-from $OVPN_DATA --rm -it $OVPN_IMAGE ovpn_initpki
-docker run --rm -it --volumes-from $OVPN_DATA $OVPN_IMAGE easyrsa gen-crl
+VOLUME_ARG=$(_volume_arg)
+
+docker volume create --name $OVPN_DATA
+docker run $VOLUME_ARG --rm $OVPN_IMAGE ovpn_genconfig -e "management localhost 7505" "$@"
+docker run --rm -it $VOLUME_ARG $OVPN_IMAGE ovpn_initpki
+docker run --rm -it $VOLUME_ARG $OVPN_IMAGE easyrsa gen-crl
 _start_vpn

--- a/libexec/easy_docker_vpn-destroy
+++ b/libexec/easy_docker_vpn-destroy
@@ -18,4 +18,10 @@ if [[ $response != YES ]]; then
 fi
 
 docker stop $OVPN_CONT
-docker rm $OVPN_CONT $OVPN_DATA
+docker rm $OVPN_CONT
+
+if [[ "$(_volume_mode)" == "container" ]]; then
+	docker rm $OVPN_DATA
+else
+	docker volume rm $OVPN_DATA
+fi

--- a/libexec/easy_docker_vpn-getconfig
+++ b/libexec/easy_docker_vpn-getconfig
@@ -16,6 +16,8 @@ if [[ -z $USER ]]; then
 	exit 1
 fi
 
-docker run --volumes-from $OVPN_DATA --rm -it $OVPN_IMAGE ovpn_getclient $USER > $USER.conn.ovpn
+VOLUME_ARG=$(_volume_arg)
+
+docker run $VOLUME_ARG --rm -it $OVPN_IMAGE ovpn_getclient $USER > $USER.conn.ovpn
 
 echo "Config for $USER saved to $USER.conn.ovpn"

--- a/libexec/easy_docker_vpn-issue
+++ b/libexec/easy_docker_vpn-issue
@@ -26,7 +26,9 @@ fi
 
 set -e
 
-docker run --volumes-from $OVPN_DATA --rm -it $OVPN_IMAGE easyrsa build-client-full $*
-docker run --volumes-from $OVPN_DATA --rm -it $OVPN_IMAGE ovpn_getclient $USER > $USER.conn.ovpn
+VOLUME_ARG=$(_volume_arg)
+
+docker run --rm -it $VOLUME_ARG $OVPN_IMAGE easyrsa build-client-full $*
+docker run --rm -it $VOLUME_ARG $OVPN_IMAGE ovpn_getclient $USER > $USER.conn.ovpn
 
 echo "Config for $USER saved to $USER.conn.ovpn"

--- a/libexec/easy_docker_vpn-list
+++ b/libexec/easy_docker_vpn-list
@@ -8,4 +8,6 @@
 
 _ensure_vpn_data
 
-docker run --volumes-from $OVPN_DATA --rm -it $OVPN_IMAGE ovpn_listclients
+VOLUME_ARG=$(_volume_arg)
+
+docker run --rm -it $VOLUME_ARG $OVPN_IMAGE ovpn_listclients

--- a/libexec/easy_docker_vpn-restore
+++ b/libexec/easy_docker_vpn-restore
@@ -22,6 +22,8 @@ fi
 
 _ensure_no_vpn_data
 
-docker create --name $OVPN_DATA -v /etc/openvpn busybox
-cat $RESTORE_TARBALL | docker run --rm -i --volumes-from $OVPN_DATA busybox tar xzvf - -C /
+VOLUME_ARG=$(_volume_arg)
+
+docker volume create --name $OVPN_DATA
+cat $RESTORE_TARBALL | docker run --rm -i $VOLUME_ARG busybox tar xzvf - -C /
 _start_vpn

--- a/libexec/easy_docker_vpn-revoke
+++ b/libexec/easy_docker_vpn-revoke
@@ -23,13 +23,15 @@ fi
 
 set -e
 
+VOLUME_ARG=$(_volume_arg)
+
 # Revoke cert
-docker run --rm -it --volumes-from $OVPN_DATA $OVPN_IMAGE easyrsa revoke $USER || true
+docker run --rm -it $VOLUME_ARG $OVPN_IMAGE easyrsa revoke $USER || true
 
 # Regenerate CRL and fix permissions
-docker run --rm -it --volumes-from $OVPN_DATA $OVPN_IMAGE easyrsa gen-crl
-docker run --rm -it --volumes-from $OVPN_DATA -w /etc/openvpn $OVPN_IMAGE cp pki/crl.pem crl.pem
-docker run --rm -it --volumes-from $OVPN_DATA -w /etc/openvpn $OVPN_IMAGE chmod 644 crl.pem
+docker run --rm -it $VOLUME_ARG $OVPN_IMAGE easyrsa gen-crl
+docker run --rm -it $VOLUME_ARG -w /etc/openvpn $OVPN_IMAGE cp pki/crl.pem crl.pem
+docker run --rm -it $VOLUME_ARG -w /etc/openvpn $OVPN_IMAGE chmod 644 crl.pem
 
 # Disconnect existing connections
 # docker exec -it $OVPN_CONT bash -c "type nc || apk --update add netcat-openbsd"


### PR DESCRIPTION
Docker has named volumes now, so this PR switches the default for new VPNs to use that instead of the older `--volumes-from` thingy.

It will continue to work with the container mode if detected, and there's migration information in the README.